### PR TITLE
parenthesize nested ternary expressions (PHP 7.4)

### DIFF
--- a/social-media-links.php
+++ b/social-media-links.php
@@ -66,7 +66,7 @@ class SocialMediaLinksPlugin extends Plugin
 		$twig = $this->grav['twig'];
 		$pages = $this->config->get('plugins.social-media-links.social_pages.pages');	
 		uasort($pages, function($a, $b) {
-			return $a['position'] < $b['position'] ? -1 : $a['position'] == $b['position'] ? 0 : 1;
+			return $a['position'] < $b['position'] ? -1 : ($a['position'] == $b['position'] ? 0 : 1);
         });
         $twig->twig_vars['social_pages'] = $pages;
 	}


### PR DESCRIPTION
Fix for

```
: Unparenthesized a ? b : c ? d : e is deprecated. Use either (a ? b : c) ? d : e or a ? b : (c ? d : e)
in xxxx/grav/user/plugins/social-media-links/social-media-links.php
on line
69
```

Nested ternary expressions (without parentheses) are deprecated in PHP 7.4.
